### PR TITLE
Load environment variables once via dotenv

### DIFF
--- a/decrypt_loader.py
+++ b/decrypt_loader.py
@@ -3,13 +3,11 @@
 
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad, unpad
-from dotenv import load_dotenv
 import os
+import security_config
 
-load_dotenv()  # 👈 This line loads your .env
-
-MODEL_KEY = os.getenv("MODEL_AES_KEY")
-if MODEL_KEY is None:
+MODEL_KEY = security_config.SECRET_KEY
+if not MODEL_KEY or MODEL_KEY == "fallback-secret-key":
     raise ValueError("MODEL_AES_KEY is not set. Check your .env file.")
 MODEL_KEY = MODEL_KEY.encode()
 

--- a/security_config.py
+++ b/security_config.py
@@ -7,6 +7,10 @@ from jose import jwt, JWTError
 from datetime import datetime, timedelta
 from passlib.hash import argon2
 import os
+from dotenv import load_dotenv, find_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv(find_dotenv())
 
 # -----------------------------
 # Config


### PR DESCRIPTION
## Summary
- Load `.env` using `load_dotenv(find_dotenv())` in `security_config`
- Use `security_config` for shared `MODEL_AES_KEY` in `decrypt_loader`

## Testing
- `python -m py_compile security_config.py decrypt_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ec4b8f560832b9ba4158102ec1eb4